### PR TITLE
Redirect guests to login and hide search on auth pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask, redirect, url_for
+from flask_login import LoginManager, current_user
 from flask_sqlalchemy import SQLAlchemy
-from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect
 from config import Config
 
@@ -29,6 +29,8 @@ def create_app(config_class=Config):
 
     @app.route('/')
     def index():
-        return redirect(url_for('listings.index'))
+        if current_user.is_authenticated:
+            return redirect(url_for('listings.index'))
+        return redirect(url_for('auth.login'))
 
     return app

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,10 +26,16 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarMain">
+
+                {% if request.endpoint and not request.endpoint.startswith('auth.') %}
                 <form class="d-flex mx-auto" style="width: 320px;" action="{{ url_for('listings.index') }}" method="get">
                     <input id="nav-search" class="form-control me-2" type="search" name="q"
                            placeholder="Search listings..." value="{{ request.args.get('q', '') }}" />
                 </form>
+                {% else %}
+                <div class="mx-auto"></div>
+                {% endif %}
+
                 <div class="ms-auto d-flex gap-2 align-items-center">
                     {% if current_user.is_authenticated %}
                         <a href="{{ url_for('listings.new') }}" class="btn btn-sm btn-light">


### PR DESCRIPTION
Updated the home route so guests are redirected to the login page, while authenticated users are redirected to listings. Also hid the navbar search bar on authentication pages such as login, signup, forgot password, and reset password.