### PR TITLE
Add listing status badges

### DIFF
--- a/app/templates/listings/detail.html
+++ b/app/templates/listings/detail.html
@@ -30,6 +30,7 @@
                     </form>
                 </div>
             {% endif %}
+
             {% if listing.image_url %}
                 <img src="{{ listing.image_url }}" class="w-100" style="max-height: 380px; object-fit: cover;" alt="{{ listing.title }}">
             {% else %}
@@ -41,9 +42,19 @@
             <div class="card-body p-4">
                 <div class="d-flex align-items-start justify-content-between gap-3 flex-wrap">
                     <div>
-                        <h3 class="fw-bold mb-1" style="color:#1d3557;">{{ listing.title }}</h3>
-                        <div class="d-flex align-items-center gap-3 mt-2">
+                        <div class="d-flex align-items-center gap-2 flex-wrap mb-1">
+                            <h3 class="fw-bold mb-0" style="color:#1d3557;">{{ listing.title }}</h3>
+
+                            {% if listing.is_active %}
+                                <span class="listing-status-badge status-active">Active</span>
+                            {% else %}
+                                <span class="listing-status-badge status-sold">Sold</span>
+                            {% endif %}
+                        </div>
+
+                        <div class="d-flex align-items-center gap-3 mt-2 flex-wrap">
                             <span class="category-badge">{{ listing.category|title }}</span>
+
                             {% if current_user.is_authenticated and current_user.id != listing.seller_id %}
                                 <button type="button"
                                         class="btn btn-sm wishlist-btn {{ 'btn-outline-danger' if current_user.has_saved(listing) else 'btn-outline-secondary' }}"
@@ -55,10 +66,14 @@
                                     (<span class="wishlist-count">{{ listing.save_count }}</span>)
                                 </button>
                             {% else %}
-                                <span class="badge bg-light text-dark border"><i class="bi bi-heart-fill text-danger me-1"></i>Saved by {{ listing.save_count }} {{ 'person' if listing.save_count == 1 else 'people' }}</span>
+                                <span class="badge bg-light text-dark border">
+                                    <i class="bi bi-heart-fill text-danger me-1"></i>
+                                    Saved by {{ listing.save_count }} {{ 'person' if listing.save_count == 1 else 'people' }}
+                                </span>
                             {% endif %}
                         </div>
                     </div>
+
                     <div class="listing-price fs-3">${{ "%.2f"|format(listing.price) }}</div>
                 </div>
 
@@ -82,16 +97,17 @@
                             Listed {{ listing.created_at.strftime('%d %B %Y') }}
                         </div>
                     </div>
+
                     {% if current_user.id != listing.seller_id %}
                         {% if listing.is_active %}
-                        <a href="{{ url_for('chat.start_chat', listing_id=listing.id) }}" class="ms-auto btn btn-success">
-                            Message Seller
-                        </a>
+                            <a href="{{ url_for('chat.start_chat', listing_id=listing.id) }}" class="ms-auto btn btn-success">
+                                Message Seller
+                            </a>
                         {% else %}
-                        <span class="badge bg-secondary ms-auto">Sold</span>
+                            <span class="listing-status-badge status-sold ms-auto">Sold</span>
                         {% endif %}
                     {% else %}
-                    <p class="text-muted ms-auto">This is your listing</p>
+                        <p class="text-muted ms-auto">This is your listing</p>
                     {% endif %}
                 </div>
 
@@ -113,7 +129,6 @@
                 {% endif %}
             </div>
             
-            <!-- Edit History Timeline (Visible if toggle is ON and edits exist) -->
             {% set edits = listing.edits.all() %}
             {% if listing.show_history and edits %}
             <div class="card-footer bg-light p-4" style="border-top: 1px solid #e5e7eb;">

--- a/app/templates/listings/index.html
+++ b/app/templates/listings/index.html
@@ -114,7 +114,17 @@
                             {% endif %}
                         </div>
                     </div>
-                    <div class="listing-price">${{ "%.2f"|format(listing.price) }}</div>
+
+                    <div class="d-flex align-items-center justify-content-between mt-2 gap-2">
+                        <div class="listing-price">${{ "%.2f"|format(listing.price) }}</div>
+
+                        {% if listing.is_active %}
+                            <span class="listing-status-badge status-active">Active</span>
+                        {% else %}
+                            <span class="listing-status-badge status-sold">Sold</span>
+                        {% endif %}
+                    </div>
+
                     <div class="d-flex align-items-center justify-content-between mt-2">
                         <span class="category-badge">{{ listing.category|title }}</span>
                         <small class="text-muted">

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -146,12 +146,17 @@
                     <h6 class="card-title mb-1 text-truncate" title="{{ listing.title }}">
                         {{ listing.title }}
                     </h6>
-                    <div class="d-flex align-items-center gap-2 mt-1">
+
+                    <div class="d-flex align-items-center justify-content-between mt-2 gap-2">
                         <div class="listing-price">${{ "%.2f"|format(listing.price) }}</div>
-                        {% if not listing.is_active %}
-                            <span class="badge bg-secondary" style="font-size:10px;">Sold</span>
+
+                        {% if listing.is_active %}
+                            <span class="listing-status-badge status-active">Active</span>
+                        {% else %}
+                            <span class="listing-status-badge status-sold">Sold</span>
                         {% endif %}
                     </div>
+
                     <div class="d-flex align-items-center justify-content-between mt-2">
                         <span class="category-badge">{{ listing.category|title }}</span>
                         <small class="text-muted">{{ listing.created_at.strftime('%d %b') }}</small>

--- a/style.css
+++ b/style.css
@@ -154,3 +154,34 @@ body {
 .switch-text a:hover {
     text-decoration: underline;
 }
+.listing-status-badge {
+
+    display: inline-block;
+
+    padding: 4px 10px;
+
+    border-radius: 999px;
+
+    font-size: 11px;
+
+    font-weight: 700;
+
+    line-height: 1;
+
+}
+
+.status-active {
+
+    background-color: #e8f7ee;
+
+    color: #198754;
+
+}
+
+.status-sold {
+
+    background-color: #eef2f7;
+
+    color: #6b7280;
+
+}


### PR DESCRIPTION
Added listing status badges for marketplace listings.

Changes included:
- added Active and Sold badges on the browse listings page
- added status badge on the listing detail page
- added status badge on profile listing cards
- added styling for the new badges in style.css

Tested on:
- listings page
- listing detail page
- profile page