### PR TITLE
Fix listing filter button alignment

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -790,3 +790,14 @@ h1, h2, h3, h4, h5 {
         flex-direction: column;
     }
 }
+/* ─── Fix listing filter Apply/Clear button alignment ─────────── */
+.listings-filter-actions .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 44px;
+    line-height: 1;
+    padding-top: 0;
+    padding-bottom: 0;
+}


### PR DESCRIPTION
The listings filter Apply button text and icon were slightly misaligned vertically. I added a small CSS rule to center the button contents using flex alignment so the Apply and Clear buttons line up consistently with the other filter controls.